### PR TITLE
update flummox

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Andrew Clark <acdlite@me.com>",
   "license": "ISC",
   "dependencies": {
-    "flummox": "~2.2.1",
+    "flummox": "~2.13.0",
     "immutable": "~3.6.2",
     "koa": "~0.16.0",
     "koa-conditional-get": "~1.0.2",


### PR DESCRIPTION
Just tried it with node `v0.12.0` and now iojs `v1.4.3` and in both cases I get this:

```
nodemon lib/server/app.js
5 Mar 23:47:52 - [nodemon] v1.3.7
5 Mar 23:47:52 - [nodemon] to restart at any time, enter `rs`
5 Mar 23:47:52 - [nodemon] watching: *.*
5 Mar 23:47:52 - [nodemon] starting `node --harmony lib/server/app.js`
App started listening on port 3000

  TypeError: Cannot convert a Symbol value to a string
      at fastKey (/Users/zigomir/development/playground/flummox-isomorphic-demo/node_modules/flummox/node_modules/6to5-runtime/core-js.js:1400:65)
      at getEntry (/Users/zigomir/development/playground/flummox-isomorphic-demo/node_modules/flummox/node_modules/6to5-runtime/core-js.js:1413:17)
      at def (/Users/zigomir/development/playground/flummox-isomorphic-demo/node_modules/flummox/node_modules/6to5-runtime/core-js.js:1421:17)
      at [object Object].getCollection.set (/Users/zigomir/development/playground/flummox-isomorphic-demo/node_modules/flummox/node_modules/6to5-runtime/core-js.js:1499:14)
      at StargazerActions.Actions (src/Actions.js:27:21)
      at new StargazerActions (../../../src/shared/actions/StargazerActions.js:6:54)
      at Object.exports.applyConstructor (/Users/zigomir/development/playground/flummox-isomorphic-demo/node_modules/flummox/node_modules/6to5-runtime/helpers.js:38:28)
      at Flux.createActions (src/Flux.js:79:9)
      at new Flux (../../src/shared/Flux.js:12:10)
      at Object.callee$1$0$ (../../../../src/server/routes/views/appIndex.js:27:16)
```

Updating `flummox` to `2.13.0` solved an issue for me.
