### PR TITLE
remove 'use strict' from ES6 modules

### DIFF
--- a/src/client/entry.js
+++ b/src/client/entry.js
@@ -1,5 +1,3 @@
-'use strict';
-
 require('../shared/init');
 
 import React from 'react';

--- a/src/client/init.js
+++ b/src/client/init.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Remove 300ms tap delay on mobile devices
 import attachFastClick from 'fastclick';
 attachFastClick(document.body);

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Initialization
 require('../shared/init');
 import sourceMapSupport from 'source-map-support';

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import middleware from './middleware';
 import appIndex from './views/appIndex';
 

--- a/src/server/routes/middleware.js
+++ b/src/server/routes/middleware.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import path from 'path';
 
 import gzip from 'koa-gzip';

--- a/src/server/routes/views/appIndex.js
+++ b/src/server/routes/views/appIndex.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React from 'react';
 import Router from 'react-router';
 import routes from '../../../shared/routes';

--- a/src/server/webpack.js
+++ b/src/server/webpack.js
@@ -1,5 +1,3 @@
-'use strict';
-
 require('../shared/init');
 
 import webpack from 'webpack';

--- a/src/shared/Flux.js
+++ b/src/shared/Flux.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { Flummox } from 'flummox';
 
 import StargazerActions from './actions/StargazerActions';

--- a/src/shared/actions/StargazerActions.js
+++ b/src/shared/actions/StargazerActions.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { Actions } from 'flummox';
 import request from 'superagent';
 

--- a/src/shared/components/AppHandler.js
+++ b/src/shared/components/AppHandler.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React from 'react';
 import { RouteHandler } from 'react-router';
 

--- a/src/shared/components/StargazerGridHandler.js
+++ b/src/shared/components/StargazerGridHandler.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React from 'react';
 import { State } from 'react-router';
 import Immutable from 'immutable';

--- a/src/shared/components/StargazerGridView.js
+++ b/src/shared/components/StargazerGridView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React from 'react';
 import Immutable from 'immutable';
 

--- a/src/shared/init.js
+++ b/src/shared/init.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*
  * Polyfills
  */

--- a/src/shared/performRouteHandlerStaticMethod.js
+++ b/src/shared/performRouteHandlerStaticMethod.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Accepts an array of matched routes as returned from react-router's
  * `Router.run()` and calls the given static method on each. The methods may

--- a/src/shared/routes.js
+++ b/src/shared/routes.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React from 'react';
 import { Route, DefaultRoute } from 'react-router';
 import AppHandler from './components/AppHandler';

--- a/src/shared/stores/StargazerStore.js
+++ b/src/shared/stores/StargazerStore.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { Store } from 'flummox';
 import Immutable from 'immutable';
 


### PR DESCRIPTION
I only removed them from where I'm sure that file is used as module (has `export` in it), but left them in in webpack configs, init and entry files. Is this ok?
