### PR TITLE
Update flummox, react, react-document-title, and react-router deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Andrew Clark <acdlite@me.com>",
   "license": "ISC",
   "dependencies": {
-    "flummox": "~2.13.0",
+    "flummox": "~3.2.1",
     "immutable": "~3.6.2",
     "koa": "~0.16.0",
     "koa-conditional-get": "~1.0.2",
@@ -33,9 +33,9 @@
     "koa-router": "~3.8.0",
     "koa-static": "~1.4.9",
     "koa-views": "~2.1.2",
-    "react": "~0.12.2",
-    "react-document-title": "~0.1.3",
-    "react-router": "~0.11.6",
+    "react": "~0.13.1",
+    "react-document-title": "~1.0.2",
+    "react-router": "~0.13.2",
     "superagent": "~0.21.0",
     "then-jade": "~2.2.1"
   },


### PR DESCRIPTION
Not sure what the status of this project was, but it was helpful to me so I thought I'd update it.

A couple warnings are now thrown:
- `Warning: Router.State is deprecated. Please use this.context.router.getCurrentParams() instead`
- `Warning: owner-based and parent-based contexts differ (values: [object Object] vs undefined) for key (flux) while mounting StargazerGrid(see: http://fb.me/react-context-by-parent)`

App still seems to work though just with upgrading, will look at addressing the warnings in a future PR.
