### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##No longer maintained. Check out the source for Flummox's [documentation](https://github.com/acdlite/flummox/tree/master/docs) for an updated version of this project.##
+## No longer maintained. Check out the source for Flummox's [documentation](https://github.com/acdlite/flummox/tree/master/docs) for an updated version of this project. ##
 
 # Flummox Isomorphic Demo
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
